### PR TITLE
Fixes #4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+WPSCAN_INSTALL_DIR=~/wpscan

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.env
 node_modules

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Kristian Nikkanen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Usage
 
 
     npm install
-    node server.js /path/to/file.txt
+    ./wpscan.js /path/to/file.txt
 
 Notes
 -----
 
-Script assumes that wpscan is installed in /usr/bin/wpscan, change that if needed.
+Default wpscan installation directory is /usr/bin/wpscan, change that via .env if needed.
 
 Very special thanks to [@pakastin](https://github.com/pakastin), couldn't have done this without his help.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Asynchronous-WPScan
 ===================
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 A simple NodeJS wrapper for WPScan. Takes a file (containing urls, separated with newlines) and uses WPScan on them.
 
@@ -7,6 +8,7 @@ Included PHP script filters out unnecessary data. Also emails the output to prov
 
 Usage
 =====
+
 
     npm install
     node server.js /path/to/file.txt

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
+    "dotenv": "^2.0.0",
     "nl2br": "0.0.3",
     "nodemailer": "^2.1.0",
     "request": "^2.69.0",

--- a/wpscan.js
+++ b/wpscan.js
@@ -1,3 +1,8 @@
+#!/usr/bin/env node
+
+require('dotenv').config(); // load dotenv
+var wpscandir = process.env.WPSCAN_INSTALL_DIR || '/usr/bin/wpscan';
+
 var cp = require('child_process');
 var fs = require('fs');
 var path = require('path');
@@ -30,9 +35,8 @@ function scanSites (urls) {
 
 function onUrl (url, next) {
   var cmd = [
-    'cd /usr/bin/wpscan;',
     'echo ' + url + ';',
-    './wpscan.rb --url=' + url + ' --batch |',
+    wpscandir + '/wpscan.rb --url=' + url + ' --batch |',
     'php ' + path.join(__dirname, 'wp_check_for_vulnerabilities.php') + ';',
     'echo ---------\n'
   ];


### PR DESCRIPTION
- Fix README instructions
- Make the main file executable for easier cli usage
- Read the wpscan install dir from env instead of hardcoding it
